### PR TITLE
Fixes bug blocking MOE SSO in staging/production

### DIFF
--- a/campus_social_auth/__init__.py
+++ b/campus_social_auth/__init__.py
@@ -4,6 +4,6 @@ A custom Campus authentication backend.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 default_app_config = 'campus_social_auth.apps.CampusSocialAuthConfig'  # pylint: disable=invalid-name

--- a/campus_social_auth/backends/utils.py
+++ b/campus_social_auth/backends/utils.py
@@ -1,4 +1,3 @@
-
 from random import randint
 
 from django.contrib.auth.models import User
@@ -60,7 +59,7 @@ class UsernameGenerator(object):
             else:
                 suffix = counter
 
-            new_username = '{}{}{}'.format(initial_username, self.separator_character, suffix)
+            new_username = u'{}{}{}'.format(initial_username, self.separator_character, suffix)
             user_exists = User.objects.filter(username=new_username).exists()
             counter = counter + 1
 


### PR DESCRIPTION
Fixes an issue in Campus stage, where names coming from the external MOE SSO are usually in Hebrew or Arabic.  This issue occurs only when a suggested username for an existing user is found, thus executing the code path repaired here.

Adds a test to reproduce and validate the fix.

Bumps version to 1.0.1 -- need to tag and update deployment version.

**JIRA tickets**: SE-1076

**Sandbox URL**: see stage.campus.gov.il

**Merge deadline**: ASAP

**Testing instructions**:

1. Register a new MOE user on stage.campus.gov.il (see ticket for credentials).
1. Logout (clearing all MOE cookies) and login again.
   When this change is not installed, the request throws a 500 error with the following stack trace:
   ```
   ...
        File "/edx/app/edxapp/venvs/edxapp/src/campus-social-auth/campus_social_auth/backends/utils.py", line 69, in generate_username
       raise exc
   UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)
   ```
   With this change, the login succeeds correctly.

The automated tests also verify this issue.  Run `tox` to validate.

**Reviewers**
- [ ] @SSPJ  